### PR TITLE
Set the default stack size to be four times greater than default in A…

### DIFF
--- a/template/config.ini
+++ b/template/config.ini
@@ -2,3 +2,4 @@
 version_notify = 0
 root_dirs = 0|/tv
 tv_download_dir = /incoming
+stack_size = 327680


### PR DESCRIPTION
…lpine, fixing a crash when loading the large Notifications settings page template file.